### PR TITLE
Implement Translated Triangular Function and Fix Rect Bug

### DIFF
--- a/src/api/signal_computer.c
+++ b/src/api/signal_computer.c
@@ -16,6 +16,8 @@
 #define phase_argpos 6
 #define interval_argpos 7
 
+int sign_double(double x);
+
 int cosine(fftw_complex in[], double input_array[],
           int total_samples, double sampling_interval,
           double a, double b, double amp, double freq_hz, double phase_rad);
@@ -161,6 +163,14 @@ int main(int argc, char *argv[])
   return 0;
 }
 
+int sign_double(double x) {
+  if (x >= 0.0) {
+      return 1;
+  } else {
+      return -1;
+  }
+}
+
 int cosine(fftw_complex in[], double input_array[],
           int total_samples, double sampling_interval,
           double a, double b, double amp, double freq_hz, double phase_rad)
@@ -264,7 +274,7 @@ int rect(fftw_complex in[], double input_array[],
     {
       input = a + i * sampling_interval + ceil(total_samples / 2) * sampling_interval;
 
-      if (fabs(input-phase_rad) - sampling_interval/2 < pulse_length/2)
+      if (fabs(input-phase_rad) < pulse_length/2 + sampling_interval/2)
       {
         in[i][0] = amp;
         in[i][1] = 0;
@@ -281,7 +291,7 @@ int rect(fftw_complex in[], double input_array[],
       input = a + i * sampling_interval - ceil(total_samples / 2) * sampling_interval - sampling_interval;
 
       int i_left_shifted = i - rightmost_index;
-      if (fabs(input - phase_rad) < pulse_length/2)
+      if (fabs(input - phase_rad) < pulse_length/2 + sampling_interval/2)
       {
         in[i][0] = amp;
         in[i][1] = 0;
@@ -338,9 +348,9 @@ int triangle(fftw_complex in[], double input_array[],
       {
         input = a + i * sampling_interval + ceil(total_samples / 2) * sampling_interval;
 
-        if (i * sampling_interval < pulse_length + sampling_interval)
+        if (fabs(input - phase_rad) < pulse_length + sampling_interval/2)
         {
-          in[i][0] = amp*(pulse_length-input)/(pulse_length);
+          in[i][0] = amp*(pulse_length - fabs(input-phase_rad))/(pulse_length);
           in[i][1] = 0;
         }
         else
@@ -355,9 +365,9 @@ int triangle(fftw_complex in[], double input_array[],
         input = a + i * sampling_interval - ceil(total_samples / 2) * sampling_interval - sampling_interval;
 
         int i_left_shifted = i - rightmost_index;
-        if (i_left_shifted * sampling_interval > floor(total_samples / 2) * sampling_interval - pulse_length + sampling_interval / 2)
+        if (fabs(input - phase_rad) < pulse_length + sampling_interval/2)
         {
-          in[i][0] = amp*(input+pulse_length)/(pulse_length);
+          in[i][0] = amp*(pulse_length - fabs(input-phase_rad))/(pulse_length);
           in[i][1] = 0;
         }
         else

--- a/src/api/signal_computer.c
+++ b/src/api/signal_computer.c
@@ -36,9 +36,9 @@ int exponential(fftw_complex in[], double input_array[],
                       int total_samples, double sampling_interval,
                       double a, double b, double amp);
 
-int triangle_centered(fftw_complex in[], double input_array[],
+int triangle(fftw_complex in[], double input_array[],
   int total_samples, double sampling_interval,
-  double a, double b, double amp, double pulse_length);
+  double a, double b, double amp, double pulse_length, double phase_rad);
   
 
 int main(int argc, char *argv[])
@@ -94,8 +94,8 @@ int main(int argc, char *argv[])
   }
   else if (!strcmp(argv[sig_argpos], "triangle"))
   {
-    rightmost_index = triangle_centered(in, input_array, total_samples, sampling_interval,
-                                      a, b, amp, pulse_length);
+    rightmost_index = triangle(in, input_array, total_samples, sampling_interval,
+                                      a, b, amp, pulse_length, phase_rad);
 
   }
   else
@@ -326,9 +326,9 @@ int exponential(fftw_complex in[], double input_array[],
   return rightmost_index;
 }
 
-int triangle_centered(fftw_complex in[], double input_array[],
+int triangle(fftw_complex in[], double input_array[],
   int total_samples, double sampling_interval,
-  double a, double b, double amp, double pulse_length)
+  double a, double b, double amp, double pulse_length, double phase_rad)
 {
   int i, rightmost_index;
   double input;

--- a/src/components/WaveForm.astro
+++ b/src/components/WaveForm.astro
@@ -107,22 +107,25 @@ function updateDynamicMax() {
 document.querySelector('.starwind-select')?.addEventListener('starwind-select:change', (event) => {
   waveformInput = (event as CustomEvent).detail.value;
 
-  let newLabel = "Frequency (f₀):";
+  let newFreqLabel = "Frequency (f₀):";
+  let newPhaseLabel = "Phase (ϕ):";
     switch (waveformInput) {
       case "square":
-        newLabel = "Duration (P):";
+        newFreqLabel = "Duration (P):";
+        newPhaseLabel = "Translate (X):";
         break;
       case "triangle":
-        newLabel = "Duration (2P):";
+        newFreqLabel = "Duration (2P):";
+        newPhaseLabel = "Translate (X):";
         break;
     }
     
     if (frequencyLabelElement) {
-      frequencyLabelElement.innerHTML = newLabel;
+      frequencyLabelElement.innerHTML = newFreqLabel;
     }
 
     if (phaseLabelElement) {
-      phaseLabelElement.innerHTML = "Translate (X):";
+      phaseLabelElement.innerHTML = newPhaseLabel;
     }
 
 });


### PR DESCRIPTION
This PR introduces the capability to generate a translated triangular pulse and also corrects a boundary condition bug in the rectangular pulse function (`rect`).

**Changes:**

1.  **Triangular Function Translation (b772929 and 6bb5ef8d):**
    *   The `triangle` function signature was updated to include a `phase_rad` parameter (b772929).
    *   The core logic of the `triangle` function was rewritten (6bb5ef8d) to:
        *   Calculate the pulse shape based on the absolute distance from the specified center: `fabs(input - phase_rad)`.
        *   Use this distance to determine the amplitude: `amp * (pulse_length - fabs(input - phase_rad)) / pulse_length`.
        *   Adjust the condition defining the pulse width to correctly center it around `phase_rad` and handle boundary samples: `fabs(input - phase_rad) < pulse_length + sampling_interval / 2`.

2.  **Rectangular Function Bug Fix (6bb5ef8d):**
    *   The conditions defining the pulse width in the `rect` function were adjusted from `fabs(input - phase_rad) - sampling_interval / 2 < pulse_length / 2` and `fabs(input - phase_rad) < pulse_length / 2` to the unified `fabs(input - phase_rad) < pulse_length / 2 + sampling_interval / 2`.
    *   This corrects a bug where the function might include one sample too many or too few at the edges of the pulse due to boundary condition handling.

3.  **Helper Function (6bb5ef8d):**
    *   Added a `sign_double` helper function.

**Motivation:**

*   Adding translation to the `triangle` function provides greater flexibility, allowing triangular pulses to be generated centered at any desired point (`phase_rad`), similar to the recent update to the `rect` function.
*   The fix to the `rect` function ensures more accurate pulse generation by correctly handling samples at the pulse boundaries.