### PR TITLE
Fixed tooltip values not updating

### DIFF
--- a/src/hooks/useLightweightChart.js
+++ b/src/hooks/useLightweightChart.js
@@ -28,17 +28,25 @@ const renderMathJax = (element,callback) => {
 const setTooltipHtml = (legend, name, time, value) => {
   if (legend) {
     let formulaDiv = legend.querySelector('.mathjax-formula');
+    let valueDiv = legend.querySelector('.value-display');
+    let timeDiv = legend.querySelector('.time-display');
 
     if (!formulaDiv) {
         legend.innerHTML = `
         <div class="mathjax-formula text-base md:text-lg my-0">${name}</div>
-        <div class="text-sm md:text-base my-0">${value}</div>
-        <div class="test-xs md:text-sm my-0">${time}</div>
+        <div class="value-display text-sm md:text-base my-0">${value}</div>
+        <div class="time-display test-xs md:text-sm my-0">${time}</div>
         `;
+
+        formulaDiv = legend.querySelector('.mathjax-formula');
+        valueDiv = legend.querySelector('.value-display');
+        timeDiv = legend.querySelector('.time-display');
     }
 
-    formulaDiv.style.visibility = 'hidden';
+    valueDiv.innerHTML = value;
+    timeDiv.innerHTML = time;
 
+    formulaDiv.style.visibility = 'hidden';
     formulaDiv.innerHTML = name;
 
     renderMathJax(formulaDiv, () => {


### PR DESCRIPTION
This PR addresses an issue where tooltip values in the Lightweight Charts were not updating dynamically.

The problem was in the `setTooltipHtml` function within `useLightweightChart.js`. It was only creating the HTML elements for value and time display once, and then trying to update their values. Since the elements were being reused and not properly targeted, the values weren't refreshing.

The fix ensures the value and time HTML elements are properly selected before updating their innerHTML, guaranteeing that the displayed values are updated correctly on each crosshair move.
