### PR TITLE
fix: call fitContent synchronously after setData to prevent zoom flash

### DIFF
--- a/src/components/signal-chart.tsx
+++ b/src/components/signal-chart.tsx
@@ -163,7 +163,6 @@ export function SignalChart() {
 
   const {
     setData: setInputChartData,
-    fitContent: fitInputChartContent,
     updateLegend: updateInputLegendManual,
   } = useLightweightChart(
     container1Ref,
@@ -175,7 +174,6 @@ export function SignalChart() {
 
   const {
     setData: setOutputChartData,
-    fitContent: fitOutputChartContent,
     updateLegend: updateOutputLegendManual,
   } = useLightweightChart(
     container2Ref,
@@ -202,8 +200,6 @@ export function SignalChart() {
         setOutputChartData(outputSignalSliced);
 
         requestAnimationFrame(() => {
-          fitInputChartContent();
-          fitOutputChartContent();
           updateInputLegendManual(undefined);
           updateOutputLegendManual(undefined);
         });
@@ -221,8 +217,6 @@ export function SignalChart() {
     getData,
     setInputChartData,
     setOutputChartData,
-    fitInputChartContent,
-    fitOutputChartContent,
     updateInputLegendManual,
     updateOutputLegendManual,
   ]);

--- a/src/hooks/use-lightweight-chart.ts
+++ b/src/hooks/use-lightweight-chart.ts
@@ -169,8 +169,9 @@ export function useLightweightChart(
   }, [containerRef, chartOptions, seriesOptions, updateLegend]);
 
   const setData = useCallback((data: ChartDataPoint[]) => {
-    if (seriesRef.current) {
+    if (seriesRef.current && chartRef.current) {
       seriesRef.current.setData(data as LineData<Time>[]);
+      chartRef.current.timeScale().fitContent();
       requestAnimationFrame(() => updateLegend(undefined));
     }
   }, [updateLegend]);


### PR DESCRIPTION
## Summary

Fixes a bug where the chart would briefly zoom to an extreme level before settling into the default zoom on page reload.

## Problem

When the chart was created, \`fitContent()\` was being called asynchronously via \`requestAnimationFrame\` after data was set. This created a brief window where the chart had data but wasn't properly scaled, causing a visible zoom flash.

## Solution

Move \`fitContent()\` to be called synchronously immediately after \`setData()\` in the \`useLightweightChart\` hook. This ensures the chart is properly scaled as soon as data is available, eliminating the visual glitch.

## Changes

- **\`src/hooks/use-lightweight-chart.ts\`**: Call \`fitContent()\` synchronously right after \`setData()\`
- **\`src/components/signal-chart.tsx\`**: Remove redundant \`fitContent()\` calls and clean up unused destructured values